### PR TITLE
replace project.entry-points.console_scripts with project.scripts

### DIFF
--- a/{{cookiecutter.hyphenated}}/pyproject.toml
+++ b/{{cookiecutter.hyphenated}}/pyproject.toml
@@ -19,7 +19,7 @@ Changelog = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutt
 Issues = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.hyphenated }}/issues"
 CI = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.hyphenated }}/actions"
 {% endif %}
-[project.entry-points.console_scripts]
+[project.scripts]
 {{ cookiecutter.hyphenated }} = "{{ cookiecutter.underscored }}.cli:cli"
 
 [project.optional-dependencies]


### PR DESCRIPTION
The [pyproject.toml specification](https://packaging.python.org/en/latest/specifications/pyproject-toml/#entry-points) says:

> Build back-ends MUST raise an error if the metadata defines a [project.entry-points.console_scripts] or [project.entry-points.gui_scripts] table, as they would be ambiguous in the face of [project.scripts] and [project.gui-scripts], respectively.

This replaces the entrypoint with `projects.scripts`, as suggested in [Writing your `pyproject.toml`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#creating-executable-scripts) article on python.org.