### PR TITLE
Update pyproject.toml

### DIFF
--- a/{{cookiecutter.hyphenated}}/pyproject.toml
+++ b/{{cookiecutter.hyphenated}}/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1"
 description = "{{ cookiecutter.description or "" }}"
 readme = "README.md"
 authors = [{name = "{{ cookiecutter.author_name }}"}]
-license = "Apache-2.0"
+license = {file = "LICENSE"}
 requires-python = ">=3.8"
 classifiers = []
 dependencies = [


### PR DESCRIPTION
Updating the license line in pyproject.toml to reference the LICENSE file. 

GitHub actions was complaining about the original line.

Error shown (selected relevant line):

```  
configuration error: `project.license` must be valid exactly by one definition (2 matches found):
```